### PR TITLE
Move dirlist cleanup to python file.

### DIFF
--- a/notebooks/Atomic Motifs.ipynb
+++ b/notebooks/Atomic Motifs.ipynb
@@ -167,8 +167,6 @@
    "outputs": [],
    "source": [
     "# Display Sliders for Parameters\n",
-    "if 'dirList' in pattern_files:\n",
-    "    pattern_files.remove('dirList')\n",
     "display_sliders(current_motif)"
    ]
   },

--- a/notebooks/python_scripts/slider_ui.py
+++ b/notebooks/python_scripts/slider_ui.py
@@ -62,6 +62,8 @@ if __name__ == "__main__":
 
     # List Pattern Text Files
     pattern_files = os.listdir("./patterns/")
+    if 'dirList' in pattern_files:
+        pattern_files.remove('dirList')
 
     if '.ipynb_checkpoints' in pattern_files:
         pattern_files.remove('.ipynb_checkpoints')


### PR DESCRIPTION
The pattern_files list is not visible in the notebook cell, so 'dirList' still showed in the dropdown.